### PR TITLE
[Removed] Extra cancancan gem entry in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'devise-async', git: 'https://github.com/mhfs/devise-async.git', branch: 'devise-4.x'
-gem 'cancancan'
 gem 'faker'
 
 group :test do 

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
-database:
-  post:
-    - bundle exec rake db:migrate
-    - bundle exec rake db:seed
+machine:
+  timezone: Asia/Kolkata
+
 test:
   post:
-    - bundle exec codeclimate-test-reporter
+    - gem install codeclimate-test-reporter && codeclimate-test-reporter

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,5 @@
 machine:
   timezone: Asia/Kolkata
-
 test:
   post:
     - gem install codeclimate-test-reporter && codeclimate-test-reporter

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  # config.action_mailer.perform_deliveries = false
   config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the stderr.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,6 +22,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.secret_key_base = ENV["SECRET_KEY_BASE"]
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
@@ -33,6 +35,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,8 @@ require 'webmock/minitest'
 # Umment for awesome colorful output
 # require "minitest/pride"
 
+WebMock.disable_net_connect!(allow: [/codeclimate.com/])
+
 module CreateOrderHelper
   def create_order
     some_time = Time.parse "10 AM"  ## gives time object in IST time zone


### PR DESCRIPTION
bundle install warning

Your Gemfile lists the gem cancancan (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of one of them later.
